### PR TITLE
reset the uwsgi buffer before each metric send

### DIFF
--- a/plugin.c
+++ b/plugin.c
@@ -122,6 +122,7 @@ static int dogstatsd_send_metric(struct uwsgi_buffer *ub, struct uwsgi_stats_pus
   memset(datadog_tags, 0, MAX_BUFFER_SIZE);
   memset(custom_tags_str, 0, MAX_BUFFER_SIZE);
   memset(datatog_metric_name, 0, MAX_BUFFER_SIZE);
+  memset(ub->buf, 0, ub->len);
 
   // let's copy original metric name before we start
   strncpy(raw_metric_name, metric, metric_len + 1);


### PR DESCRIPTION
Before the buffer would end up like this sometimes:

`uwsgi.worker.requests:0|c|#worker:21,wsgi_app:badges_api_app:badges_apiges_api`